### PR TITLE
Add prometheus setup + alert manager start

### DIFF
--- a/monitoring/alert_manager.yml
+++ b/monitoring/alert_manager.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+  namespace: monitoring
+data:
+  alertmanager.yml: |-
+    global:
+      smtp_smarthost: 'smtp.example.com:587'
+      smtp_from: 'alertmanager@example.com'
+      smtp_auth_username: 'your-username'
+      smtp_auth_password: 'your-password'
+
+    route:
+      receiver: 'email-notifications'
+
+    receivers:
+    - name: 'email-notifications'
+      email_configs:
+      - to: 'your-email@example.com'

--- a/monitoring/monitoring.yml
+++ b/monitoring/monitoring.yml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: monitor
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: service-app
+  endpoints:
+  - interval: 30s

--- a/monitoring/prometheus_rule.yml
+++ b/monitoring/prometheus_rule.yml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: service-alerts
+  namespace: monitoring
+spec:
+  groups:
+  - name: service.rules
+    rules:
+    - alert: HighRequestRate
+      expr: rate(http_requests_total[2m]) > 15
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High request rate"
+        description: "The service is receiving more than 15 requests per minute for the last 2 minutes."

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -4,5 +4,24 @@
   become: yes
   tasks:
     - name: Download and install Helm
-      debug:
-        msg: "TODO"
+      shell: |
+        curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+        sudo apt-get install apt-transport-https --yes
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+        sudo apt-get update
+        sudo apt-get install helm
+
+    - name: Add Prometheus Repository
+      command: helm repo add prom-repo https://prometheus-community.github.io/helm-charts
+
+    - name: Update Helm repos
+      command: helm repo update
+
+    - name: Install Prometheus Stack
+      command: helm install prometheus prom-repo/kube-prometheus-stack
+
+    - name: Apply monitoring yaml files
+      shell: |
+        minikube kubectl apply -f /vagrant/monitoring/monitoring.yaml
+        minikube kubectl apply -f /vagrant/monitoring/prometheus_rule.yml
+        minikube kubectl apply -f /vagrant/monitoring/alert_manager.yml


### PR DESCRIPTION
This is the basic to the prometheus setup. Haven't been able to test it ofc...

This should cover the sufficient category but we also need to add the metrics to the app for it to be completed.

This depends on the other pr first though, i.e. Make the app deployable to a kubernetes cluster 